### PR TITLE
ci: update node version from 20 to 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Fix

Il workflow di release usa Node.js 20, ma `semantic-release@25` e `@semantic-release/npm@13` richiedono Node.js >=22.14.0.

## Changes
- `node-version: 20` → `node-version: 22` in entrambi i job (test e release)

## Note
Risolve anche gli engine warnings per `file-type@22`, `pipenet@1.4.2` che richiedono Node >=22.